### PR TITLE
Upgrade Nlog to v5.2.2 (Support build trimming)

### DIFF
--- a/src/Elmah.Io.NLog/Elmah.Io.NLog.csproj
+++ b/src/Elmah.Io.NLog/Elmah.Io.NLog.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.0.5" />
+    <PackageReference Include="NLog" Version="5.2.2" />
     <PackageReference Include="Elmah.Io.Client" Version="[5.2.118,6)" />
   </ItemGroup>
 


### PR DESCRIPTION
If using [NLog Fluent Config API](https://github.com/NLog/NLog/wiki/Fluent-Configuration-API), then one can register Elmah-Target to avoid assembly-loading and reflection:
```c#
var logger = LogManager.Setup().SetupExtensions(ext => ext.RegisterTarget<ElmahIoTarget>()).GetCurrentClassLogger();
logger.Info("Hello World");
```
See also: https://nlog-project.org/2023/05/30/nlog-5-2-trim-warnings.html