### PR TITLE
Added TargetFrameworks net461

### DIFF
--- a/src/Elmah.Io.NLog/Elmah.Io.NLog.csproj
+++ b/src/Elmah.Io.NLog/Elmah.Io.NLog.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>elmah.io target for NLog</Description>
     <Authors>elmah.io</Authors>
-    <TargetFrameworks>net45;netstandard1.4;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net461;netstandard1.4;netstandard2.0</TargetFrameworks>
     <AssemblyName>Elmah.Io.NLog</AssemblyName>
     <PackageId>Elmah.Io.NLog</PackageId>
     <PackageTags>Error;Exception;Reporting;Management;Logging;ELMAH;Diagnostics;Tracing;NLog</PackageTags>
@@ -16,7 +16,7 @@
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net45' ">true</DisableImplicitFrameworkReferences>
+    <DisableImplicitFrameworkReferences Condition=" $(TargetFramework.StartsWith('net4')) ">true</DisableImplicitFrameworkReferences>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <EnablePackageValidation>true</EnablePackageValidation>
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>


### PR DESCRIPTION
net45 is not included by default in Visual Studio 2022

Notice build-pipeline is not happy about `netstandard1.4`:
> Targeting .NET Standard prior to 2.0 is no longer recommended